### PR TITLE
Adds group sync for Azure Groups via token to Django groups #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ AZURE_AUTH = {
     "LOGOUT_URI": "https://<domain>/logout",    # Optional
     "PUBLIC_URLS": ["<public:view_name>",]  # Optional, public views accessible by non-authenticated users
     "PUBLIC_PATHS": ['/go/',],  # Optional, public paths accessible by non-authenticated users
+    "ROLES": {
+        "95170e67-2bbf-4e3e-a4d7-e7e5829fe7a7": "GroupName1",
+        "3dc6539e-0589-4663-b782-fef100d839aa": "GroupName2"
+    }  # Optional, will add user to django group if user is in EntraID group
 }
 LOGIN_URL = "/azure_auth/login"
 LOGIN_REDIRECT_URL = "/"    # Or any other endpoint
@@ -119,9 +123,24 @@ that the request includes the session and user objects. Public URLs which need t
 non-authenticated users should be specified in the `settings.AZURE_AUTH["PUBLIC_URLS"]`, as
 shown above.
 
-## Planned development
+## Groups Management
+Adding a group to the Azure Enterprise application will pass the group id down to the application via the token.
+This happens only, if the user is part of the group. In this case the group will be listed in the `token`.
 
-- Groups management
+On how to configure this in Azure see here: https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-fed-group-claims
+
+Groups available in the token are synced with the corresponding django groups. Therfor the group id's from Azure need to be mapped in the 
+settings with the Django groups by adding the following to `AZURE_AUTH` in `settings`.
+```
+"ROLES": {
+        "95170e67-2bbf-4e3e-a4d7-e7e5829fe7a7": "GroupName1",
+        "3dc6539e-0589-4663-b782-fef100d839aa": "GroupName2"
+    }
+```
+If a user is assigned to one or more of this groups listed in the configuration, the user will be added
+automatically to the respective Django group. The group will be created if it does not exist. 
+If a user is not part of a group (revoke permissions case), but is still in the Django group, the user
+will be removed from the Django group. 
 
 ## Credits
 

--- a/azure_auth/handlers.py
+++ b/azure_auth/handlers.py
@@ -4,6 +4,7 @@ import msal
 import requests
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 
 from azure_auth.exceptions import DjangoAzureAuthException, TokenError
 

--- a/azure_auth/handlers.py
+++ b/azure_auth/handlers.py
@@ -97,7 +97,26 @@ class AuthHandler:
             user.last_name = attr if (attr := azure_user["surname"]) else ""
             user.save()
 
-        # TODO: Handle groups
+        # Syncing azure token claim roles with django user groups
+        # A role mapping in the AZURE_AUTH settings is expected.
+        role_mappings = settings.AZURE_AUTH.get("ROLES")
+        if role_mappings:
+            # Check if id_token_claims and roles are available
+            if token.get("id_token_claims", None):
+                azure_token_roles = token.get("id_token_claims", None).get("roles", None)
+
+                for role, group_name in role_mappings.items():
+                    # all groups are created by default if they not exist
+                    django_group = Group.objects.get_or_create(name=group_name)[0]
+                    
+                    if role in azure_token_roles:
+                        # user has permissions so we add him to the corresponding django group
+                        user.groups.add(django_group)
+                    else:
+                        # user has no permission check if user is in group and remove if so
+                        if user.groups.filter(name=group_name).exists():
+                            user.groups.remove(django_group)
+            
         return user
 
     @staticmethod

--- a/azure_auth/tests/conftest.py
+++ b/azure_auth/tests/conftest.py
@@ -57,6 +57,7 @@ def token(request):
             "tid": "dummy_id_token_claims_tid",
             "uti": "dummy_id_token_claims_uti",
             "ver": "2.0",
+            "roles": ["95170e67-2bbf-4e3e-a4d7-e7e5829fe7a7"],
         },
     }
 

--- a/azure_auth/tests/settings.py
+++ b/azure_auth/tests/settings.py
@@ -136,6 +136,10 @@ AZURE_AUTH = {
     "LOGOUT_URI": "http://mydomain/logout",
     "PUBLIC_URLS": ["public", "decorator_protected"],
     "PUBLIC_PATHS": ["/public_external"],
+    "ROLES": {
+        "95170e67-2bbf-4e3e-a4d7-e7e5829fe7a7": "GroupName1",
+        "3dc6539e-0589-4663-b782-fef100d839aa": "GroupName2"
+    }
 }
 LOGIN_URL = "/azure_auth/login"
 LOGIN_REDIRECT_URL = "/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-azure-auth"
-version = "1.1.0"
+version = "1.2.0"
 description = "A simple Django app for user authentication with Azure Active Directory."
 authors = ["AgileTek Engineering <london@agiletek.co.uk>"]
 license = "MIT"


### PR DESCRIPTION
Adds the support to pass a AzureAD (now EntraID) group that has been added to the Enterprise application, down to the Django application where it is synced with Django groups. 

As described in the issue #15

A mapping needs to be provided in the settings. Based on this mapping the groups are created and a user is assigned an removed from a group when the group id is present in the role claim within the token. 

I tried to get the test as best as I could. Bare with me ;-)