### PR TITLE
Add setting for groups attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ AZURE_AUTH = {
         "3dc6539e-0589-4663-b782-fef100d839aa": "GroupName2"
     },  # Optional, will add user to django group if user is in EntraID group
     "USERNAME_ATTRIBUTE": "mail",   # The AAD attribute or ID token claim you want to use as the value for the user model `USERNAME_FIELD`
+    "GROUP_ATTRIBUTE": "roles",   # The AAD attribute or ID token claim you want to use as the value for the user's group memberships
     "EXTRA_FIELDS": [], # Optional, extra AAD user profile attributes you want to make available in the user mapping function
     "USER_MAPPING_FN": "azure_auth.tests.misc.user_mapping_fn", # Optional, path to the function used to map the AAD to Django attributes
     "GRAPH_USER_ENDPOINT": "https://graph.microsoft.com/v1.0/me", # Optional, URL to the Graph endpoint that returns user info
@@ -185,7 +186,7 @@ Adding a group to the Azure Enterprise application will pass the group id down t
 On how to configure this optional group claim in Azure see here: https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-fed-group-claims
 
 > [!NOTE]
-> Note that the default key will be `groups` though while the app expects this information under the `roles` key of the `id_token`. To make sure that the group information is fed down as a role claim, select the **Emit groups as role claims** checkbox, when configuring the group claims (https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-fed-group-claims#customize-group-claim-name).
+> Note that the default key will be `groups` though while the app expects this information under the `roles` key of the `id_token`. To make sure that the group information is fed down as a role claim, select the **Emit groups as role claims** checkbox, when configuring the group claims (https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-fed-group-claims#customize-group-claim-name). Alternatively, you can set `settings.AZURE_AUTH.GROUP_ATTRIBUTE = 'groups'` to use the default attribute
 
 
 Groups available in the token are synced with the corresponding django groups. Therfor the group id's from Azure need to be mapped in the

--- a/azure_auth/handlers.py
+++ b/azure_auth/handlers.py
@@ -119,10 +119,18 @@ class AuthHandler:
                 **self._map_attributes_to_user(**attributes),
             )
 
-        # Syncing azure token claim roles with django user groups
-        # A role mapping in the AZURE_AUTH settings is expected.
+        user = self.sync_groups(user, token)
+
+        return user
+
+    # Syncing azure token claim roles with django user groups
+    # A role mapping in the AZURE_AUTH settings is expected.
+    # The attribute of the token to use for group membership can be specified
+    #   in AZURE_AUTH.GROUP_ATTRIBUTE
+    def sync_groups(self, user, token):
         role_mappings = settings.AZURE_AUTH.get("ROLES")
-        azure_token_roles = token.get("id_token_claims", {}).get("roles", None)
+        groups_attr = settings.AZURE_AUTH.get("GROUP_ATTRIBUTE", "roles")
+        azure_token_roles = token.get("id_token_claims", {}).get(groups_attr, None)
         if role_mappings:  # pragma: no branch
             for role, group_name in role_mappings.items():
                 # all groups are created by default if they not exist


### PR DESCRIPTION
This resolves #43 by adding a setting to select which token attribute to use for group syncing. It also splits the group  syncing step out into an independent function to allow users to easily override it if needed for more complicated group mapping.