### PR TITLE
Optimize group operations

### DIFF
--- a/azure_auth/apps.py
+++ b/azure_auth/apps.py
@@ -22,3 +22,13 @@ def azure_auth_check(app_configs, **kwargs):
 class AzureAuthConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "azure_auth"
+
+    def ready(self) -> None:
+        from django.contrib.auth.models import Group
+
+        role_mappings = settings.AZURE_AUTH.get("ROLES")
+
+        for group_name in role_mappings.values():
+            Group.objects.get_or_create(name=group_name)
+
+        return super().ready()

--- a/azure_auth/apps.py
+++ b/azure_auth/apps.py
@@ -22,13 +22,3 @@ def azure_auth_check(app_configs, **kwargs):
 class AzureAuthConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "azure_auth"
-
-    def ready(self) -> None:
-        from django.contrib.auth.models import Group
-
-        role_mappings = settings.AZURE_AUTH.get("ROLES")
-
-        for group_name in role_mappings.values():
-            Group.objects.get_or_create(name=group_name)
-
-        return super().ready()

--- a/azure_auth/handlers.py
+++ b/azure_auth/handlers.py
@@ -14,6 +14,7 @@ from django.http import HttpRequest
 from azure_auth.exceptions import DjangoAzureAuthException, TokenError
 
 UserModel = cast(AbstractBaseUser, get_user_model())
+GROUPS_UPDATED = false
 
 
 class AuthHandler:
@@ -118,6 +119,12 @@ class AuthHandler:
                 **{UserModel.USERNAME_FIELD: natural_key},  # type: ignore
                 **self._map_attributes_to_user(**attributes),
             )
+
+        if not GROUPS_UPDATED:
+            role_mappings = settings.AZURE_AUTH.get("ROLES")
+            for group_name in role_mappings.values():
+                Group.objects.get_or_create(name=group_name)
+            GROUPS_UPDATED = True
 
         # Syncing azure token claim roles with django user groups
         # A role mapping in the AZURE_AUTH settings is expected.


### PR DESCRIPTION
This makes a few changes to the way groups are handled in order to reduce the number of queries executed for each login. 

1. Groups are created once at startup. Previously this executed one query per line in the role mapping on every login. This was redundant and scales poorly with large mappings or lots of users.
2. Previously the user's groups were queried one time for each entry in the role mapping to determine whether a group should be removed. Now the groups are queried a single time to return all relations.
3. Adding and removing groups was done individually, now it is done in batches, and only if there are items to add or remove.

The result of these changes is that authenticating a user now executes strictly fewer queries and a constant, rather than linear, number.

If the mapping has `n` entries, here is the change in query count for different situations:

| Situation                                | Previous | New |
|----------------------------|----------|------|
| No group changes needed | `2n`         | `1` |
| Add `x` groups                    | `2n`         | `2` |
| Remove `y` groups             | `2n + y`   | `2` |
| Add `x`, remove `y`            | `2n + y`   | `3` |

The add and remove queries could be combined, however a user may be a member of many groups, and this would require using the explicit `set` method and sending the name of every group in the query. This would both increase bandwidth as well as potentially leading to database portability issues.