### PR TITLE
Create URL and path lists only once

### DIFF
--- a/azure_auth/middleware.py
+++ b/azure_auth/middleware.py
@@ -11,20 +11,19 @@ from .handlers import AuthHandler
 class AzureMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
-
-    def __call__(self, request: HttpRequest):
         public_views = ["azure_auth:login", "azure_auth:logout", "azure_auth:callback"]
         public_views.extend(settings.AZURE_AUTH.get("PUBLIC_URLS", []))
-        public_urls = [reverse(view_name) for view_name in public_views]
-        public_paths = settings.AZURE_AUTH.get(
+        self.public_urls = [reverse(view_name) for view_name in public_views]
+        self.public_paths = settings.AZURE_AUTH.get(
             "PUBLIC_PATHS", []
         )  # added to resolve paths
 
-        if request.path_info in public_urls:
+    def __call__(self, request: HttpRequest):
+        if request.path_info in self.public_urls:
             return self.get_response(request)
 
         # Added to resolve paths that can't be reversed
-        for path in public_paths:
+        for path in self.public_paths:
             if request.path_info.startswith(path):
                 return self.get_response(request)
 


### PR DESCRIPTION
The lists only need to be constructed, when the middleware is initialized on startup.