### PR TITLE
Allow mapping to multiple groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ AZURE_AUTH = {
     "PUBLIC_URLS": ["<public:view_name>",],  # Optional, public views accessible by non-authenticated users
     "PUBLIC_PATHS": ['/go/',],  # Optional, public paths accessible by non-authenticated users
     "ROLES": {
-        "95170e67-2bbf-4e3e-a4d7-e7e5829fe7a7": "GroupName1",
-        "3dc6539e-0589-4663-b782-fef100d839aa": "GroupName2"
+        "95170e67-2bbf-4e3e-a4d7-e7e5829fe7a7": "GroupName1", # mapped to one Django group
+        "3dc6539e-0589-4663-b782-fef100d839aa": ["GroupName2", "GroupName3"] # mapped to multiple Django groups
     },  # Optional, will add user to django group if user is in EntraID group
     "USERNAME_ATTRIBUTE": "mail",   # The AAD attribute or ID token claim you want to use as the value for the user model `USERNAME_FIELD`
     "GROUP_ATTRIBUTE": "roles",   # The AAD attribute or ID token claim you want to use as the value for the user's group memberships

--- a/azure_auth/tests/test_handler.py
+++ b/azure_auth/tests/test_handler.py
@@ -1,5 +1,6 @@
 from collections import ChainMap
 
+import pytest
 from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import RequestFactory, TestCase, override_settings
@@ -8,6 +9,8 @@ from django.urls import reverse_lazy
 from azure_auth.handlers import AuthHandler
 
 
+@pytest.mark.django_db
+@pytest.mark.usefixtures("token")
 class TestAzureAuthHandler(TestCase):
     def setUp(self):
         self.request_factory = RequestFactory()
@@ -48,3 +51,108 @@ class TestAzureAuthHandler(TestCase):
         req = self.request_factory.get("/")
         self.session_midleware.process_request(req)
         return AuthHandler(req)
+
+    def test_group_mapping(self):
+        handler = self._build_auth_handler()
+        handler.sync_groups(self.user, self.token)
+        self.assertEqual(self.user.groups.count(), 1)
+
+    @override_settings(
+        AZURE_AUTH=ChainMap(
+            {
+                "ROLES": {
+                    # Just some random GUID, that is not in the token
+                    "a1ad6d75-11c5-442b-9b32-17bdebe82427": "GroupName1",
+                }
+            },
+            settings.AZURE_AUTH,
+        )
+    )
+    def test_no_mapping(self):
+        handler = self._build_auth_handler()
+        handler.sync_groups(self.user, self.token)
+        self.assertEqual(self.user.groups.count(), 0)
+
+    @override_settings(
+        AZURE_AUTH=ChainMap(
+            {
+                "ROLES": {
+                    "95170e67-2bbf-4e3e-a4d7-e7e5829fe7a7": ["GroupName1"],
+                }
+            },
+            settings.AZURE_AUTH,
+        )
+    )
+    def test_single_group_list_mapping(self):
+        handler = self._build_auth_handler()
+        handler.sync_groups(self.user, self.token)
+        self.assertEqual(self.user.groups.count(), 1)
+
+    @override_settings(
+        AZURE_AUTH=ChainMap(
+            {
+                "ROLES": {
+                    "95170e67-2bbf-4e3e-a4d7-e7e5829fe7a7": [
+                        "GroupName1",
+                        "GroupName2",
+                    ],
+                }
+            },
+            settings.AZURE_AUTH,
+        )
+    )
+    def test_multi_group_list_mapping(self):
+        handler = self._build_auth_handler()
+        handler.sync_groups(self.user, self.token)
+        self.assertEqual(self.user.groups.count(), 2)
+
+    @override_settings(
+        AZURE_AUTH=ChainMap(
+            {
+                "ROLES": {
+                    "95170e67-2bbf-4e3e-a4d7-e7e5829fe7a7": [
+                        "GroupName1",
+                        "",
+                    ],
+                }
+            },
+            settings.AZURE_AUTH,
+        )
+    )
+    def test_multi_group_list_mapping_with_empty(self):
+        handler = self._build_auth_handler()
+        handler.sync_groups(self.user, self.token)
+        self.assertEqual(self.user.groups.count(), 1)
+
+    @override_settings(
+        AZURE_AUTH=ChainMap(
+            {
+                "ROLES": {
+                    "95170e67-2bbf-4e3e-a4d7-e7e5829fe7a7": [
+                        "GroupName1",
+                        None,
+                    ],
+                }
+            },
+            settings.AZURE_AUTH,
+        )
+    )
+    def test_multi_group_list_mapping_with_none(self):
+        handler = self._build_auth_handler()
+        handler.sync_groups(self.user, self.token)
+        self.assertEqual(self.user.groups.count(), 1)
+
+    @override_settings(
+        AZURE_AUTH=ChainMap(
+            {
+                "ROLES": {
+                    "95170e67-2bbf-4e3e-a4d7-e7e5829fe7a7": [],
+                }
+            },
+            settings.AZURE_AUTH,
+        )
+    )
+    def test_empty_group_list_mapping(self):
+        handler = self._build_auth_handler()
+        handler.sync_groups(self.user, self.token)
+        self.assertEqual(self.user.groups.count(), 0)


### PR DESCRIPTION
This allows groups / roles from Azure to be mapped to multiple groups in Django. I tried to make the implementation fault tolerant for empty or `None` group names. It is also backwards compatible and accepts a single mapping with a `str`.