### PR TITLE
Add ability to use Public Client application type; control over the prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ from your Azure app:
 ```python
 AZURE_AUTH = {
     "CLIENT_ID": "<client id>",
-    "CLIENT_TYPE": "confidential", # leave unset for confidential or pick "confidential" or "public"
+    "CLIENT_TYPE": "confidential", # Optional, pick "public" or "confidential" (default)
     "CLIENT_SECRET": "<client secret>", # optional for public applications
     # REDIRECT_URI must be set to one of
     # - an absolute URI starting with "http" or "https", e. g. https://<domain>/azure_auth/callback
@@ -58,6 +58,7 @@ AZURE_AUTH = {
     # - a call to reverse_lazy, e. g. reverse_lazy("azure_auth:callback")
     "REDIRECT_URI": "https://<domain>/azure_auth/callback",
     "SCOPES": ["User.Read"],
+    "PROMPT": "select_account",  # Optional, one of "login", "consent", "select_account", "none" (default)
     "AUTHORITY": "https://login.microsoftonline.com/<tenant id>",   # Or https://login.microsoftonline.com/common if multi-tenant
     "LOGOUT_URI": "https://<domain>/logout",    # Optional
     "PUBLIC_URLS": ["<public:view_name>",],  # Optional, public views accessible by non-authenticated users

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ from your Azure app:
 ```python
 AZURE_AUTH = {
     "CLIENT_ID": "<client id>",
-    "CLIENT_SECRET": "<client secret>",
+    "CLIENT_TYPE": "confidential", # leave unset for confidential or pick "confidential" or "public"
+    "CLIENT_SECRET": "<client secret>", # optional for public applications
     # REDIRECT_URI must be set to one of
     # - an absolute URI starting with "http" or "https", e. g. https://<domain>/azure_auth/callback
     # - a relative URI starting with "/", e. g. /azure_auth/callback

--- a/azure_auth/handlers.py
+++ b/azure_auth/handlers.py
@@ -50,6 +50,7 @@ class AuthHandler:
             scopes=settings.AZURE_AUTH["SCOPES"],
             redirect_uri=redirect_uri,
             state=state,
+            prompt=settings.AZURE_AUTH.get("PROMPT", None),
         )
         self.request.session[self.auth_flow_session_key] = flow
         return flow["auth_uri"]


### PR DESCRIPTION
This PR adds the ability to use the Public Client application type as well as more normal Confidential Client type.
The difference between them is explained here:
https://learn.microsoft.com/en-us/entra/identity-platform/msal-client-applications

Public clients do not need to hold secrets or certificates to prove their identity, which makes them easier to deploy.

This PR adds some additional configuration to control the client type, with documentation updated to match in README.md
The configuration changes are backwards compatible: older settings.py files with `AZURE_AUTH` config from before this PR will continue to operate as before.  The public-client feature is enabled by the new setting `CLIENT_TYPE`.

This PR also adds a new configuration setting to control the user prompting behaviour.  Again, this is backwards compatible: older settings will continue to get their previous behaviour.  Values for `prompt` and their meaning are given here:
https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#request-an-authorization-code
Options are: `login`, `none`, `consent`, `select_account`
Not setting this lets the msal SDK chose, which currently means `none`.
