### PR TITLE
fix: Only last Azure group is assinged in Django

### DIFF
--- a/azure_auth/tests/conftest.py
+++ b/azure_auth/tests/conftest.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 from django.contrib.auth import get_user_model
 from mixer.backend.django import mixer
+from azure_auth.handlers import AuthHandler
 
 UserModel = get_user_model()
 
@@ -17,6 +18,11 @@ def user(request):
     if request.cls:
         request.cls.user = _user
     return _user
+
+
+@pytest.fixture(scope="function", autouse=True)
+def clean_groups():
+    AuthHandler.GROUPS_UPDATED = False
 
 
 @pytest.fixture(scope="function")

--- a/azure_auth/tests/test_handler.py
+++ b/azure_auth/tests/test_handler.py
@@ -157,3 +157,24 @@ class TestAzureAuthHandler(TestCase):
         handler = self._build_auth_handler()
         handler.sync_groups(self.user, self.token)
         self.assertEqual(self.user.groups.count(), 0)
+
+    @override_settings(
+        AZURE_AUTH=ChainMap(
+            {
+                "ROLES": {
+                    "95170e67-2bbf-4e3e-a4d7-e7e5829fe7a7": [
+                        "GroupName1",
+                        "GroupName2",
+                        "GroupName3",
+                    ],
+                    "cfa8556d-dd93-420c-abd2-477ba336d2d6": "GroupName1",
+                    "e236600b-7062-4bff-8ccf-12d8fbd80e5f": "GroupName1",
+                }
+            },
+            settings.AZURE_AUTH,
+        )
+    )
+    def test_multiple_roles_to_one_group(self):
+        handler = self._build_auth_handler()
+        handler.sync_groups(self.user, self.token)
+        self.assertEqual(self.user.groups.count(), 3)


### PR DESCRIPTION
With the following configuration
```python
"ROLES": {
    "ROLE1": ["GROUP1", "GROUP2", "GROUP3"],
    "ROLE2": "GROUP1",
    "ROLE3": "GROUP1",
},# Optional, will add user to django group if user is in EntraID group
``` 
 only users with ROLE3 where added correctly.

This fixes the bug reported in https://github.com/Weird-Sheep-Labs/django-azure-auth/pull/62 with the method from https://github.com/Weird-Sheep-Labs/django-azure-auth/pull/45 adapted to the multi-group feature from https://github.com/Weird-Sheep-Labs/django-azure-auth/pull/54.

Thanks to @edek437 for the bug report and @joshuata for the optimized implementation.
